### PR TITLE
Power meter calibration

### DIFF
--- a/src/Ozymandias OBJ_Scanner.cfg
+++ b/src/Ozymandias OBJ_Scanner.cfg
@@ -294,6 +294,8 @@ hardware:
         module.Class: 'powermeter.TLPMpowermeter.PowerMeter'
         options:
             address: 'USB0::0x1313::0x807B::16072030::INSTR'
+            multiplicationFactor: 114.2
+            wavelength: 532
 
     piezo1:
         module.Class: 'Piezo.APTpiezo.APTPiezo'

--- a/src/qudi/gui/LAC_PID/ui_LAC_PID_gui.ui
+++ b/src/qudi/gui/LAC_PID/ui_LAC_PID_gui.ui
@@ -40,7 +40,7 @@
                 </property>
                 <property name="icon">
                  <iconset>
-                  <normaloff>C:\Users\Ozymandias\anaconda3\envs\qudi-env\Lib\site-packages\qudi\artwork\icons\start-counter.png</normaloff>C:\Users\Ozymandias\anaconda3\envs\qudi-env\Lib\site-packages\qudi\artwork\icons\start-counter.png</iconset>
+                  <normaloff>../../../../../anaconda3/envs/qudi-env/Lib/site-packages/qudi/artwork/icons/start-counter.png</normaloff>../../../../../anaconda3/envs/qudi-env/Lib/site-packages/qudi/artwork/icons/start-counter.png</iconset>
                 </property>
                </widget>
               </item>
@@ -51,7 +51,7 @@
                 </property>
                 <property name="icon">
                  <iconset>
-                  <normaloff>C:\Users\Ozymandias\anaconda3\envs\qudi-env\Lib\site-packages\qudi\artwork\icons\stop-counter.png</normaloff>C:\Users\Ozymandias\anaconda3\envs\qudi-env\Lib\site-packages\qudi\artwork\icons\stop-counter.png</iconset>
+                  <normaloff>../../../../../anaconda3/envs/qudi-env/Lib/site-packages/qudi/artwork/icons/stop-counter.png</normaloff>../../../../../anaconda3/envs/qudi-env/Lib/site-packages/qudi/artwork/icons/stop-counter.png</iconset>
                 </property>
                </widget>
               </item>
@@ -101,6 +101,12 @@
                  <font>
                   <pointsize>8</pointsize>
                  </font>
+                </property>
+                <property name="decimals">
+                 <number>0</number>
+                </property>
+                <property name="maximum">
+                 <double>10000.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -193,6 +199,9 @@
             <pointsize>8</pointsize>
            </font>
           </property>
+          <property name="decimals">
+           <number>4</number>
+          </property>
          </widget>
         </item>
        </layout>
@@ -217,6 +226,9 @@
            <font>
             <pointsize>8</pointsize>
            </font>
+          </property>
+          <property name="decimals">
+           <number>4</number>
           </property>
          </widget>
         </item>

--- a/src/qudi/gui/LAC_PID/ui_LAC_PID_gui.ui
+++ b/src/qudi/gui/LAC_PID/ui_LAC_PID_gui.ui
@@ -200,7 +200,7 @@
            </font>
           </property>
           <property name="decimals">
-           <number>4</number>
+           <number>5</number>
           </property>
          </widget>
         </item>
@@ -228,7 +228,7 @@
            </font>
           </property>
           <property name="decimals">
-           <number>4</number>
+           <number>5</number>
           </property>
          </widget>
         </item>
@@ -254,6 +254,9 @@
            <font>
             <pointsize>8</pointsize>
            </font>
+          </property>
+          <property name="decimals">
+           <number>5</number>
           </property>
          </widget>
         </item>

--- a/src/qudi/hardware/powermeter/TLPMpowermeter.py
+++ b/src/qudi/hardware/powermeter/TLPMpowermeter.py
@@ -44,6 +44,9 @@ class PowerMeter(SimpleDataInterface, ProcessInterface):
 
     _address = ConfigOption('address', missing='error')
     _timeout = ConfigOption('timeout', 1)
+    _multiplicationFactor = ConfigOption("multiplicationFactor", 1) #This is the factor used to multiply the registered value of the power meter.
+    #This factor comes from uses where the power meter is being used to measure a small percentage of the overall signal.
+    _wavelength = ConfigOption('wavelength', 532)
     _power_meter = None
 
     def on_activate(self):
@@ -81,6 +84,8 @@ class PowerMeter(SimpleDataInterface, ProcessInterface):
             time.sleep(1) #minimize?
         
         self.power = 0
+        self.set_wavelength(self._wavelength)
+
 
 
     def on_deactivate(self):
@@ -102,8 +107,8 @@ class PowerMeter(SimpleDataInterface, ProcessInterface):
         """
         power =  c_double()
         self.tlPM.measPower(byref(power))
-        self.power = power.value *10**6
-
+        self.power = power.value*10**6
+        self.power=self.power*self._multiplicationFactor
         return self.power
 
     def get_process_value(self):


### PR DESCRIPTION
Updated the power meter to have a multiplication factor so that the delivered power can be calculated after calibration. The config file and the LAC PID code were updated to reflect the new value range which is approximately 100X larger than the measured value. Other minor changes to the LAC GUI were made to allow for different PID values to be used.
