### PR TITLE
removed old piezo module (just from GUI)

### DIFF
--- a/src/Ozymandias OBJ_Scanner-9-12-24.cfg
+++ b/src/Ozymandias OBJ_Scanner-9-12-24.cfg
@@ -19,6 +19,7 @@ gui:
       qtlogic: qutagLogic
     allow_remote: false
     options: {}
+  # Keep this piezo stage only!!
   pi_piezo_stage_gui:
     module.Class: Piezo.piezogui.PiezoGUI
     connect:
@@ -108,12 +109,13 @@ gui:
       pmlogic: powermeterLogic
     allow_remote: false
     options: {}
-  piezogui:
-    module.Class: Piezo.piezogui.PiezoGUI
-    connect:
-      apt_logic: aptLogic
-    allow_remote: false
-    options: {}
+  # only need to comment this out?
+  # piezogui:
+  #   module.Class: Piezo.piezogui.PiezoGUI
+  #   connect:
+  #     apt_logic: aptLogic
+  #   allow_remote: false
+  #   options: {}
   count_gui:
     module.Class: counter.counter_gui.CounterGUI
     options:


### PR DESCRIPTION
Updated Config File to remove Thorlabs Piezo from GUI

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Unneeded GUI was left behind in the config file. Just removed from GUI by commenting out the relevant config file sections.

## Types of changes
- [ X] Bug fix
- [ ] New feature
- [ ] Breaking change (Causes existing functionality to not work as expected)

